### PR TITLE
show section magestat in website and store scopes

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -14,7 +14,7 @@
         <tab id="magestat" translate="label" sortOrder="900">
             <label>Magestat</label>
         </tab>
-        <section id="magestat_cookielawbanner" showInDefault="1">
+        <section id="magestat_cookielawbanner" showInDefault="1" showInStore="1" showInWebsite="1">
             <tab>magestat</tab>
             <label>Cookie Law Banner</label>
             <resource>Magestat_CookieLawBanner::config</resource>


### PR DESCRIPTION
The magestat tab in Magento configuration has to be shown in Website and Store scope, too. Otherwise it is not possible to translate the cookie banner information.